### PR TITLE
fix: stop AI skeleton loading when generation was never triggered

### DIFF
--- a/apps/web/app/s/[videoId]/Share.tsx
+++ b/apps/web/app/s/[videoId]/Share.tsx
@@ -216,30 +216,11 @@ const useVideoStatus = (
 				}
 
 				if (data.transcriptionStatus === "COMPLETE") {
-					if (!aiGenerationEnabled) {
-						return false;
-					}
-
-					if (
-						data.aiGenerationStatus === "SKIPPED" ||
-						data.aiGenerationStatus === "ERROR" ||
-						data.aiGenerationStatus === "COMPLETE"
-					) {
-						return false;
-					}
-
-					if (
-						data.aiGenerationStatus === "QUEUED" ||
-						data.aiGenerationStatus === "PROCESSING"
-					) {
-						return true;
-					}
-
-					if (!data.aiGenerationStatus && !data.summary && !data.chapters) {
-						return true;
-					}
-
-					return false;
+					return (
+						aiGenerationEnabled &&
+						(data.aiGenerationStatus === "QUEUED" ||
+							data.aiGenerationStatus === "PROCESSING")
+					);
 				}
 
 				return false;
@@ -326,22 +307,10 @@ export const Share = ({
 		}
 
 		if (transcriptionStatus === "COMPLETE") {
-			if (
-				aiData.aiGenerationStatus === "SKIPPED" ||
-				aiData.aiGenerationStatus === "ERROR" ||
-				aiData.aiGenerationStatus === "COMPLETE"
-			) {
-				return false;
-			}
-			if (
+			return (
 				aiData.aiGenerationStatus === "QUEUED" ||
 				aiData.aiGenerationStatus === "PROCESSING"
-			) {
-				return true;
-			}
-			if (!aiData.aiGenerationStatus && !aiData.summary && !aiData.chapters) {
-				return true;
-			}
+			);
 		}
 
 		return false;


### PR DESCRIPTION
## Summary

- Fix permanent loading skeleton on share page when AI API keys are not configured
- Simplify `shouldShowLoading()` and polling logic: only show loading when `aiGenerationStatus` is explicitly `QUEUED` or `PROCESSING`

## Root Cause

When self-hosting without `GROQ_API_KEY`/`OPENAI_API_KEY`, the server never triggers AI generation, so `aiGenerationStatus` stays `null`. But the client-side `shouldShowLoading()` treated `null` status + no AI data as "still loading," causing an infinite skeleton.

The server-side `getVideoStatus` already handles this correctly — when it can't trigger generation (no API keys), it returns `aiGenerationStatus: null`. The client just needs to trust that `null` means "not happening."

## Changes

- `apps/web/app/s/[videoId]/Share.tsx`: Simplified both `shouldShowLoading()` and the polling `shouldContinuePolling()` to only return `true` when status is `QUEUED` or `PROCESSING`

## Test plan

- [ ] Self-host without AI keys → no loading skeleton below video
- [ ] Self-host with AI keys → skeleton shows during processing, disappears when complete
- [ ] Existing Cap.so behavior unchanged (aiGenerationEnabled gates the loading)

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)