### PR TITLE
feat: add Deepgram EU endpoint option for GDPR compliance

### DIFF
--- a/apps/web/workflows/transcribe.ts
+++ b/apps/web/workflows/transcribe.ts
@@ -240,7 +240,13 @@ async function transcribeWithDeepgram(audioUrl: string): Promise<string> {
 
 	const audioBuffer = Buffer.from(await audioResponse.arrayBuffer());
 
-	const deepgram = createClient(serverEnv().DEEPGRAM_API_KEY as string);
+	const deepgramOptions = serverEnv().DEEPGRAM_API_URL
+		? { global: { url: serverEnv().DEEPGRAM_API_URL } }
+		: undefined;
+	const deepgram = createClient(
+		serverEnv().DEEPGRAM_API_KEY as string,
+		deepgramOptions,
+	);
 
 	const { result, error } = await deepgram.listen.prerecorded.transcribeFile(
 		audioBuffer,

--- a/packages/env/server.ts
+++ b/packages/env/server.ts
@@ -83,6 +83,12 @@ function createServerEnv() {
 
 			/// AI providers
 			DEEPGRAM_API_KEY: z.string().optional().describe("Audio transcription"),
+			DEEPGRAM_API_URL: z
+				.string()
+				.optional()
+				.describe(
+					"Deepgram API URL. Set to https://api.eu.deepgram.com for EU data residency",
+				),
 			ANTHROPIC_API_KEY: z.string().optional().describe("AI chat"),
 			OPENAI_API_KEY: z.string().optional().describe("AI summaries"),
 			GROQ_API_KEY: z.string().optional().describe("AI summaries"),


### PR DESCRIPTION
## Summary

- Add `DEEPGRAM_API_URL` env var to route transcription through Deepgram's EU endpoint
- Backwards-compatible: without the env var, behavior is unchanged

## Changes

| File | Change |
|------|--------|
| `packages/env/server.ts` | Add optional `DEEPGRAM_API_URL` with description |
| `apps/web/workflows/transcribe.ts` | Pass `global.url` to Deepgram SDK `createClient()` when set |

## Usage

```env
DEEPGRAM_API_URL=https://api.eu.deepgram.com
```

This routes all audio transcription through Deepgram's EU endpoint (AWS EU regions). Same SDK, same API, same Nova-3 model — just EU data residency.

## Test plan

- [ ] Without `DEEPGRAM_API_URL` → transcription works normally (default endpoint)
- [ ] With `DEEPGRAM_API_URL=https://api.eu.deepgram.com` → transcription works via EU
- [ ] VTT output quality identical between endpoints

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)