### PR TITLE
fix: stop AI skeleton loading when generation was never triggered

### DIFF
--- a/apps/web/app/s/[videoId]/Share.tsx
+++ b/apps/web/app/s/[videoId]/Share.tsx
@@ -235,10 +235,6 @@ const useVideoStatus = (
 						return true;
 					}
 
-					if (!data.aiGenerationStatus && !data.summary && !data.chapters) {
-						return true;
-					}
-
 					return false;
 				}
 
@@ -247,6 +243,7 @@ const useVideoStatus = (
 
 			return shouldContinuePolling() ? 2000 : false;
 		},
+		refetchOnMount: "always",
 		refetchIntervalInBackground: false,
 		staleTime: 1000,
 	});
@@ -337,9 +334,6 @@ export const Share = ({
 				aiData.aiGenerationStatus === "QUEUED" ||
 				aiData.aiGenerationStatus === "PROCESSING"
 			) {
-				return true;
-			}
-			if (!aiData.aiGenerationStatus && !aiData.summary && !aiData.chapters) {
 				return true;
 			}
 		}


### PR DESCRIPTION
## Summary

Fixes an infinite loading skeleton on the share page when self-hosting Cap without AI API keys configured.

Closes #3

## Changes

- **`apps/web/app/s/[videoId]/Share.tsx`**
  - Removed the null-status fallback check (`!aiGenerationStatus && !summary && !chapters`) in both `shouldContinuePolling` and `shouldShowLoading` that incorrectly treated a missing AI generation status as "still loading"
  - Added `refetchOnMount: "always"` to ensure one initial server fetch fires on page load, triggering AI generation when keys are present

## Root cause

On self-hosted instances, `userIsPro()` returns `true` (no `NEXT_PUBLIC_IS_CAP`), so `aiGenerationEnabled` is always `true`. But without `GROQ_API_KEY` or `OPENAI_API_KEY`, `getVideoStatus` never triggers AI generation, leaving `aiGenerationStatus` as `null` permanently. The null-status fallback treated this as "generation pending" and kept polling/showing the skeleton indefinitely.

## Test plan

- [ ] Self-hosted instance without AI keys → no skeleton, share page loads normally
- [ ] Instance with AI keys → skeleton shows during QUEUED/PROCESSING, disappears on COMPLETE/ERROR/SKIPPED
- [ ] Verify AI generation still triggers on first page load (via refetchOnMount)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>