### PR TITLE
feat: add configurable Deepgram API URL for EU data residency

### DIFF
--- a/apps/web/workflows/transcribe.ts
+++ b/apps/web/workflows/transcribe.ts
@@ -240,7 +240,14 @@ async function transcribeWithDeepgram(audioUrl: string): Promise<string> {
 
 	const audioBuffer = Buffer.from(await audioResponse.arrayBuffer());
 
-	const deepgram = createClient(serverEnv().DEEPGRAM_API_KEY as string);
+	const deepgramApiUrl = serverEnv().DEEPGRAM_API_URL;
+	const deepgramOptions = deepgramApiUrl
+		? { global: { url: deepgramApiUrl } }
+		: undefined;
+	const deepgram = createClient(
+		serverEnv().DEEPGRAM_API_KEY as string,
+		deepgramOptions,
+	);
 
 	const { result, error } = await deepgram.listen.prerecorded.transcribeFile(
 		audioBuffer,

--- a/packages/env/server.ts
+++ b/packages/env/server.ts
@@ -83,6 +83,12 @@ function createServerEnv() {
 
 			/// AI providers
 			DEEPGRAM_API_KEY: z.string().optional().describe("Audio transcription"),
+			DEEPGRAM_API_URL: z
+				.string()
+				.optional()
+				.describe(
+					"Deepgram API URL. Set to https://api.eu.deepgram.com for EU data residency",
+				),
 			ANTHROPIC_API_KEY: z.string().optional().describe("AI chat"),
 			OPENAI_API_KEY: z.string().optional().describe("AI summaries"),
 			GROQ_API_KEY: z.string().optional().describe("AI summaries"),


### PR DESCRIPTION
## Summary

Adds a `DEEPGRAM_API_URL` environment variable to route Deepgram transcription requests through a custom endpoint. Setting this to `https://api.eu.deepgram.com` ensures all audio data is processed within the EU for GDPR compliance.

Closes #2

## Changes

- **`packages/env/server.ts`** — Added `DEEPGRAM_API_URL` optional env var
- **`apps/web/workflows/transcribe.ts`** — Pass `global.url` option to Deepgram SDK when `DEEPGRAM_API_URL` is set

## Configuration

```env
DEEPGRAM_API_URL=https://api.eu.deepgram.com
```

When unset, behavior is identical to upstream (uses Deepgram's default US endpoint).

## Test plan

- [ ] Set `DEEPGRAM_API_URL=https://api.eu.deepgram.com` → transcription works via EU endpoint
- [ ] Unset `DEEPGRAM_API_URL` → transcription uses default endpoint (no change from upstream)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>