### PR TITLE
feat: add Mistral as AI provider for metadata generation and translation

### DIFF
--- a/apps/web/actions/videos/get-status.ts
+++ b/apps/web/actions/videos/get-status.ts
@@ -126,7 +126,9 @@ export async function getVideoStatus(
 		video.transcriptionStatus === "COMPLETE" &&
 		!metadata.aiGenerationStatus &&
 		!metadata.summary &&
-		(serverEnv().GROQ_API_KEY || serverEnv().OPENAI_API_KEY);
+		(serverEnv().MISTRAL_API_KEY ||
+			serverEnv().GROQ_API_KEY ||
+			serverEnv().OPENAI_API_KEY);
 
 	if (shouldTriggerAiGeneration) {
 		try {

--- a/apps/web/actions/videos/translate-transcript.ts
+++ b/apps/web/actions/videos/translate-transcript.ts
@@ -2,6 +2,7 @@
 
 import { db } from "@cap/database";
 import { s3Buckets, videos } from "@cap/database/schema";
+import { serverEnv } from "@cap/env";
 import { S3Buckets } from "@cap/web-backend";
 import type { Video } from "@cap/web-domain";
 import { eq } from "drizzle-orm";
@@ -38,7 +39,7 @@ export async function translateTranscript(
 	}
 
 	const groq = getGroqClient();
-	if (!groq) {
+	if (!groq && !serverEnv().MISTRAL_API_KEY) {
 		return {
 			success: false,
 			message: "Translation service not configured",
@@ -97,7 +98,7 @@ export async function translateTranscript(
 	const translatedVtt = await translateVttContent(
 		originalVtt.value,
 		targetLanguage,
-		groq,
+		groq ?? undefined,
 	);
 
 	if (!translatedVtt) {
@@ -127,7 +128,7 @@ export async function translateTranscript(
 async function translateVttContent(
 	vttContent: string,
 	targetLanguage: LanguageCode,
-	groq: NonNullable<ReturnType<typeof getGroqClient>>,
+	groq?: NonNullable<ReturnType<typeof getGroqClient>>,
 ): Promise<string | null> {
 	const targetLanguageName = SUPPORTED_LANGUAGES[targetLanguage];
 
@@ -146,22 +147,59 @@ VTT content to translate:
 
 ${vttContent}`;
 
-	try {
-		const response = await groq.chat.completions.create({
-			model: GROQ_MODEL,
-			messages: [{ role: "user", content: prompt }],
-			temperature: 0.3,
-			max_tokens: 8000,
-		});
-
-		const content = response.choices[0]?.message?.content;
-		if (content?.includes("WEBVTT")) {
-			return content.trim();
+	if (serverEnv().MISTRAL_API_KEY) {
+		try {
+			const res = await fetch("https://api.mistral.ai/v1/chat/completions", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: `Bearer ${serverEnv().MISTRAL_API_KEY}`,
+				},
+				body: JSON.stringify({
+					model: "mistral-small-latest",
+					messages: [{ role: "user", content: prompt }],
+					temperature: 0.3,
+					max_tokens: 8000,
+				}),
+			});
+			if (res.ok) {
+				const json = await res.json();
+				const content = json.choices?.[0]?.message?.content;
+				if (content?.includes("WEBVTT")) {
+					return content.trim();
+				}
+			} else {
+				console.error(
+					"[translateVttContent] Mistral translation non-ok response:",
+					res.status,
+					res.statusText,
+				);
+			}
+		} catch (error) {
+			console.error(
+				"[translateVttContent] Mistral translation error, trying fallback:",
+				error,
+			);
 		}
-
-		return null;
-	} catch (error) {
-		console.error("[translateVttContent] Translation error:", error);
-		return null;
 	}
+
+	if (groq) {
+		try {
+			const response = await groq.chat.completions.create({
+				model: GROQ_MODEL,
+				messages: [{ role: "user", content: prompt }],
+				temperature: 0.3,
+				max_tokens: 8000,
+			});
+
+			const content = response.choices[0]?.message?.content;
+			if (content?.includes("WEBVTT")) {
+				return content.trim();
+			}
+		} catch (error) {
+			console.error("[translateVttContent] Groq translation error:", error);
+		}
+	}
+
+	return null;
 }

--- a/apps/web/lib/generate-ai.ts
+++ b/apps/web/lib/generate-ai.ts
@@ -16,10 +16,14 @@ export async function startAiGeneration(
 	videoId: Video.VideoId,
 	userId: string,
 ): Promise<GenerateAiResult> {
-	if (!serverEnv().GROQ_API_KEY && !serverEnv().OPENAI_API_KEY) {
+	if (
+		!serverEnv().MISTRAL_API_KEY &&
+		!serverEnv().GROQ_API_KEY &&
+		!serverEnv().OPENAI_API_KEY
+	) {
 		return {
 			success: false,
-			message: "Missing AI API keys (Groq or OpenAI)",
+			message: "Missing AI API keys (Mistral, Groq, or OpenAI)",
 		};
 	}
 

--- a/apps/web/workflows/generate-ai.ts
+++ b/apps/web/workflows/generate-ai.ts
@@ -274,23 +274,64 @@ async function callAiApi(
 	prompt: string,
 	groqClient: ReturnType<typeof getGroqClient>,
 ): Promise<string> {
-	if (groqClient) {
+	if (serverEnv().MISTRAL_API_KEY) {
 		try {
-			const completion = await groqClient.chat.completions.create({
-				messages: [{ role: "user", content: prompt }],
-				model: GROQ_MODEL,
-			});
-			return completion.choices?.[0]?.message?.content || "{}";
-		} catch (groqError) {
+			return await callMistral(prompt);
+		} catch (mistralError) {
+			if (groqClient) {
+				return callWithGroqFallback(prompt, groqClient);
+			}
 			if (serverEnv().OPENAI_API_KEY) {
 				return callOpenAi(prompt);
 			}
-			throw groqError;
+			throw mistralError;
 		}
-	} else if (serverEnv().OPENAI_API_KEY) {
+	}
+	if (groqClient) {
+		return callWithGroqFallback(prompt, groqClient);
+	}
+	if (serverEnv().OPENAI_API_KEY) {
 		return callOpenAi(prompt);
 	}
 	return "{}";
+}
+
+async function callWithGroqFallback(
+	prompt: string,
+	groqClient: NonNullable<ReturnType<typeof getGroqClient>>,
+): Promise<string> {
+	try {
+		const completion = await groqClient.chat.completions.create({
+			messages: [{ role: "user", content: prompt }],
+			model: GROQ_MODEL,
+		});
+		return completion.choices?.[0]?.message?.content || "{}";
+	} catch (groqError) {
+		if (serverEnv().OPENAI_API_KEY) {
+			return callOpenAi(prompt);
+		}
+		throw groqError;
+	}
+}
+
+async function callMistral(prompt: string): Promise<string> {
+	const aiRes = await fetch("https://api.mistral.ai/v1/chat/completions", {
+		method: "POST",
+		headers: {
+			"Content-Type": "application/json",
+			Authorization: `Bearer ${serverEnv().MISTRAL_API_KEY}`,
+		},
+		body: JSON.stringify({
+			model: "mistral-small-latest",
+			messages: [{ role: "user", content: prompt }],
+		}),
+	});
+	if (!aiRes.ok) {
+		const errorText = await aiRes.text();
+		throw new Error(`Mistral API error: ${aiRes.status} ${errorText}`);
+	}
+	const aiJson = await aiRes.json();
+	return aiJson.choices?.[0]?.message?.content || "{}";
 }
 
 async function callOpenAi(prompt: string): Promise<string> {

--- a/packages/env/server.ts
+++ b/packages/env/server.ts
@@ -83,6 +83,10 @@ function createServerEnv() {
 
 			/// AI providers
 			DEEPGRAM_API_KEY: z.string().optional().describe("Audio transcription"),
+			MISTRAL_API_KEY: z
+				.string()
+				.optional()
+				.describe("AI metadata via Mistral (EU-hosted, GDPR-compliant)"),
 			ANTHROPIC_API_KEY: z.string().optional().describe("AI chat"),
 			OPENAI_API_KEY: z.string().optional().describe("AI summaries"),
 			GROQ_API_KEY: z.string().optional().describe("AI summaries"),


### PR DESCRIPTION
## Summary

Adds Mistral API (`mistral-small-latest`) as an AI provider for video metadata generation (title, summary, chapters) and transcript translation. Mistral is a French company that processes all data exclusively in the EU, making it suitable for GDPR-compliant deployments.

Closes #1

## Changes

- **`packages/env/server.ts`** — Added `MISTRAL_API_KEY` env var
- **`apps/web/workflows/generate-ai.ts`** — Added `callMistral()` function, `callWithGroqFallback()` helper, updated `callAiApi()` fallback chain
- **`apps/web/lib/generate-ai.ts`** — Added `MISTRAL_API_KEY` to availability check
- **`apps/web/actions/videos/get-status.ts`** — Added `MISTRAL_API_KEY` to generation trigger condition
- **`apps/web/actions/videos/translate-transcript.ts`** — Mistral as primary translator with Groq fallback

### Fallback chains

**Metadata generation:** Mistral → Groq → OpenAI → empty `{}`
**Transcript translation:** Mistral → Groq → `null`

When `MISTRAL_API_KEY` is not set, behavior is identical to upstream.

## Configuration

```env
MISTRAL_API_KEY=your-key-here
```

## Test plan

- [ ] Set only `MISTRAL_API_KEY` → AI generation produces title, summary, chapters
- [ ] Set only `GROQ_API_KEY` → existing behavior unchanged
- [ ] Set both → Mistral is used first
- [ ] Set no AI keys → AI generation skipped gracefully
- [ ] Test transcript translation with Mistral key → valid VTT output
- [ ] Test Mistral failure → falls back to Groq/OpenAI

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>