### PR TITLE
fix(embed): mint a per-request token instead of a shared password cookie

### DIFF
--- a/apps/web/__tests__/unit/password-cookie.test.ts
+++ b/apps/web/__tests__/unit/password-cookie.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const cookieStore = { entries: [] as { name: string; value: string }[] };
+
+vi.mock("server-only", () => ({}));
+vi.mock("next/headers", () => ({
+	cookies: async () => ({
+		getAll: () => cookieStore.entries,
+		get: (name: string) => cookieStore.entries.find((c) => c.name === name),
+		set: () => {},
+	}),
+}));
+vi.mock("@cap/database/crypto", () => ({
+	decrypt: async (value: string) => {
+		if (value.startsWith("bad")) throw new Error("cannot decrypt");
+		return value.replace(/^enc:/, "");
+	},
+	encrypt: async (value: string) => `enc:${value}`,
+}));
+
+import {
+	getVerifiedPasswordHashes,
+	perVideoPasswordCookieName,
+} from "@/lib/password-cookie";
+
+describe("perVideoPasswordCookieName", () => {
+	it("namespaces the cookie by video id", () => {
+		expect(perVideoPasswordCookieName("abc123")).toBe("x-cap-password-abc123");
+	});
+});
+
+describe("getVerifiedPasswordHashes", () => {
+	beforeEach(() => {
+		cookieStore.entries = [];
+	});
+
+	it("collects hashes from every per-video cookie", async () => {
+		cookieStore.entries = [
+			{ name: "x-cap-password-video1", value: "enc:hashOne" },
+			{ name: "x-cap-password-video2", value: "enc:hashTwo" },
+		];
+
+		await expect(getVerifiedPasswordHashes()).resolves.toEqual([
+			"hashOne",
+			"hashTwo",
+		]);
+	});
+
+	it("still reads the shared cookie alongside per-video cookies", async () => {
+		cookieStore.entries = [
+			{ name: "x-cap-password", value: 'enc:["sharedOne","sharedTwo"]' },
+			{ name: "x-cap-password-video1", value: "enc:hashOne" },
+		];
+
+		const hashes = await getVerifiedPasswordHashes();
+		expect(hashes).toContain("sharedOne");
+		expect(hashes).toContain("sharedTwo");
+		expect(hashes).toContain("hashOne");
+	});
+
+	it("ignores unrelated cookies", async () => {
+		cookieStore.entries = [
+			{ name: "next-auth.session-token", value: "enc:secret" },
+			{ name: "x-cap-password-video1", value: "enc:hashOne" },
+		];
+
+		await expect(getVerifiedPasswordHashes()).resolves.toEqual(["hashOne"]);
+	});
+
+	it("skips cookies that fail to decrypt without losing the others", async () => {
+		cookieStore.entries = [
+			{ name: "x-cap-password-video1", value: "badCookie" },
+			{ name: "x-cap-password-video2", value: "enc:hashTwo" },
+		];
+
+		await expect(getVerifiedPasswordHashes()).resolves.toEqual(["hashTwo"]);
+	});
+
+	it("deduplicates a hash present in several cookies", async () => {
+		cookieStore.entries = [
+			{ name: "x-cap-password-video1", value: "enc:sameHash" },
+			{ name: "x-cap-password-video2", value: "enc:sameHash" },
+		];
+
+		await expect(getVerifiedPasswordHashes()).resolves.toEqual(["sameHash"]);
+	});
+});

--- a/apps/web/__tests__/unit/password-cookie.test.ts
+++ b/apps/web/__tests__/unit/password-cookie.test.ts
@@ -85,3 +85,39 @@ describe("getVerifiedPasswordHashes", () => {
 		await expect(getVerifiedPasswordHashes()).resolves.toEqual(["sameHash"]);
 	});
 });
+
+describe("per-video cookie payloads", () => {
+	beforeEach(() => {
+		cookieStore.entries = [];
+	});
+
+	it("reads the timestamped payload format written by the proxy", async () => {
+		cookieStore.entries = [
+			{
+				name: "x-cap-password-video1",
+				value: 'enc:{"h":"hashOne","t":1700000000}',
+			},
+		];
+
+		await expect(getVerifiedPasswordHashes()).resolves.toEqual(["hashOne"]);
+	});
+
+	it("still reads bare-hash cookies written before the payload format", async () => {
+		cookieStore.entries = [
+			{ name: "x-cap-password-video1", value: "enc:legacyHash" },
+		];
+
+		await expect(getVerifiedPasswordHashes()).resolves.toEqual(["legacyHash"]);
+	});
+
+	it("mixes payload, legacy and shared-array cookies", async () => {
+		cookieStore.entries = [
+			{ name: "x-cap-password", value: 'enc:["sharedHash"]' },
+			{ name: "x-cap-password-video1", value: 'enc:{"h":"newHash","t":1}' },
+			{ name: "x-cap-password-video2", value: "enc:legacyHash" },
+		];
+
+		const hashes = await getVerifiedPasswordHashes();
+		expect(hashes.sort()).toEqual(["legacyHash", "newHash", "sharedHash"]);
+	});
+});

--- a/apps/web/lib/password-cookie-shared.ts
+++ b/apps/web/lib/password-cookie-shared.ts
@@ -15,6 +15,12 @@ export function perVideoPasswordCookieName(videoId: string) {
 // the set is capped and the oldest entries are retired once it is reached.
 export const MAX_PER_VIDEO_COOKIES = 12;
 
+// Retirement is primarily age-based because that decision depends only on the
+// cookie being examined, so concurrent embeds reach the same answer instead of
+// racing over a shared view of the jar. The count cap is a backstop.
+export const PER_VIDEO_COOKIE_MAX_AGE_SECONDS = 3600;
+export const PER_VIDEO_COOKIE_STALE_AFTER_SECONDS = 1800;
+
 export type PerVideoPasswordPayload = {
 	h: string;
 	t: number;

--- a/apps/web/lib/password-cookie-shared.ts
+++ b/apps/web/lib/password-cookie-shared.ts
@@ -9,3 +9,24 @@ export const PER_VIDEO_PASSWORD_COOKIE_PREFIX = "x-cap-password-";
 export function perVideoPasswordCookieName(videoId: string) {
 	return `${PER_VIDEO_PASSWORD_COOKIE_PREFIX}${videoId}`;
 }
+
+// A viewer can open many distinct password-protected embeds inside the cookie
+// lifetime. Every per-video cookie is sent on every request to this origin, so
+// the set is capped and the oldest entries are retired once it is reached.
+export const MAX_PER_VIDEO_COOKIES = 12;
+
+export type PerVideoPasswordPayload = {
+	h: string;
+	t: number;
+};
+
+export function isPerVideoPasswordPayload(
+	value: unknown,
+): value is PerVideoPasswordPayload {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		typeof (value as PerVideoPasswordPayload).h === "string" &&
+		typeof (value as PerVideoPasswordPayload).t === "number"
+	);
+}

--- a/apps/web/lib/password-cookie-shared.ts
+++ b/apps/web/lib/password-cookie-shared.ts
@@ -1,0 +1,11 @@
+export const VERIFIED_PASSWORD_COOKIE = "x-cap-password";
+
+// Embeds authorise per video via `x-cap-password-<videoId>` cookies. Several
+// embeds can load in parallel, so they must not share one cookie: concurrent
+// requests each read the same stale value before writing, and the last
+// Set-Cookie would evict the others.
+export const PER_VIDEO_PASSWORD_COOKIE_PREFIX = "x-cap-password-";
+
+export function perVideoPasswordCookieName(videoId: string) {
+	return `${PER_VIDEO_PASSWORD_COOKIE_PREFIX}${videoId}`;
+}

--- a/apps/web/lib/password-cookie.ts
+++ b/apps/web/lib/password-cookie.ts
@@ -3,6 +3,7 @@ import "server-only";
 import { decrypt, encrypt } from "@cap/database/crypto";
 import { cookies } from "next/headers";
 import {
+	isPerVideoPasswordPayload,
 	PER_VIDEO_PASSWORD_COOKIE_PREFIX,
 	VERIFIED_PASSWORD_COOKIE,
 } from "./password-cookie-shared";
@@ -40,6 +41,9 @@ async function decodeHashes(cookieValue: string): Promise<string[]> {
 			parsed.every((hash) => typeof hash === "string")
 		) {
 			return parsed;
+		}
+		if (isPerVideoPasswordPayload(parsed)) {
+			return [parsed.h];
 		}
 	} catch {
 		// Legacy cookie: the decrypted value is the hash itself.

--- a/apps/web/lib/password-cookie.ts
+++ b/apps/web/lib/password-cookie.ts
@@ -2,8 +2,14 @@ import "server-only";
 
 import { decrypt, encrypt } from "@cap/database/crypto";
 import { cookies } from "next/headers";
+import {
+	PER_VIDEO_PASSWORD_COOKIE_PREFIX,
+	VERIFIED_PASSWORD_COOKIE,
+} from "./password-cookie-shared";
 
-const COOKIE_NAME = "x-cap-password";
+export { perVideoPasswordCookieName } from "./password-cookie-shared";
+
+const COOKIE_NAME = VERIFIED_PASSWORD_COOKIE;
 
 // A verified hash is ~64 base64 chars, so 10 entries encrypt to well under
 // the 4KB cookie limit while covering any realistic number of concurrently
@@ -16,10 +22,7 @@ const MAX_VERIFIED_HASHES = 10;
  * resource never evicts another; pre-array cookies that hold a single bare
  * hash are still accepted.
  */
-export async function getVerifiedPasswordHashes(): Promise<string[]> {
-	const cookieValue = (await cookies()).get(COOKIE_NAME)?.value;
-	if (!cookieValue) return [];
-
+async function decodeHashes(cookieValue: string): Promise<string[]> {
 	let decrypted: string;
 	try {
 		// decrypt is async — without the await its rejection (corrupt or stale
@@ -42,6 +45,23 @@ export async function getVerifiedPasswordHashes(): Promise<string[]> {
 		// Legacy cookie: the decrypted value is the hash itself.
 	}
 	return [decrypted];
+}
+
+export async function getVerifiedPasswordHashes(): Promise<string[]> {
+	const store = await cookies();
+	const relevant = store
+		.getAll()
+		.filter(
+			(cookie) =>
+				cookie.name === COOKIE_NAME ||
+				cookie.name.startsWith(PER_VIDEO_PASSWORD_COOKIE_PREFIX),
+		);
+
+	const decoded = await Promise.all(
+		relevant.map((cookie) => decodeHashes(cookie.value)),
+	);
+
+	return [...new Set(decoded.flat())];
 }
 
 /**

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -1,12 +1,11 @@
 import { db } from "@cap/database";
-import { encrypt } from "@cap/database/crypto";
 import { organizations, videos } from "@cap/database/schema";
 import { buildEnv, serverEnv } from "@cap/env";
 import type { Video } from "@cap/web-domain";
 import { eq } from "drizzle-orm";
 import { notFound } from "next/navigation";
 import { type NextRequest, NextResponse, userAgent } from "next/server";
-import { verifyEmbedToken } from "@/lib/embed-token";
+import { signEmbedToken, verifyEmbedToken } from "@/lib/embed-token";
 
 const addHttps = (s?: string) => {
 	if (!s) return s;
@@ -74,59 +73,45 @@ export async function proxy(request: NextRequest) {
 	if (path.startsWith("/embed/")) {
 		const videoIdMatch = path.match(/^\/embed\/([^/]+)/);
 		const videoId = videoIdMatch?.[1];
-		let encryptedPassword: string | null = null;
+		let mintedTokenUrl: URL | null = null;
 
 		if (videoId) {
-			let authenticated = false;
+			let hasValidToken = false;
 
 			const token = url.searchParams.get("token");
 			if (token && token.length > 0 && token.length < 2048) {
 				try {
 					const result = await verifyEmbedToken(token, videoId);
-					authenticated = result.valid;
+					hasValidToken = result.valid;
 				} catch (e) {
 					console.error("Embed token verification failed:", e);
 				}
 			}
 
-			if (!authenticated) {
-				authenticated = isFromAllowedEmbedOrigin(request);
-			}
-
-			if (authenticated) {
+			if (!hasValidToken && isFromAllowedEmbedOrigin(request)) {
 				try {
 					const [video] = await db()
 						.select({ password: videos.password })
 						.from(videos)
 						.where(eq(videos.id, videoId as Video.VideoId));
+
 					if (video?.password) {
-						encryptedPassword = await encrypt(video.password);
+						const mintedToken = await signEmbedToken(videoId, "24h");
+						mintedTokenUrl = new URL(url);
+						mintedTokenUrl.searchParams.set("token", mintedToken);
 					}
 				} catch (e) {
-					console.error("Embed password lookup failed:", e);
+					console.error("Embed token minting failed:", e);
 				}
 			}
 		}
 
-		if (encryptedPassword) {
-			request.cookies.set("x-cap-password", encryptedPassword);
-		}
-
-		const response = NextResponse.next({
-			request: { headers: request.headers },
-		});
+		const response = mintedTokenUrl
+			? NextResponse.rewrite(mintedTokenUrl)
+			: NextResponse.next();
 		response.headers.set("Access-Control-Allow-Origin", "*");
 		response.headers.set("Access-Control-Allow-Methods", "GET, OPTIONS");
 		response.headers.delete("X-Frame-Options");
-
-		if (encryptedPassword) {
-			response.cookies.set("x-cap-password", encryptedPassword, {
-				httpOnly: true,
-				secure: process.env.NODE_ENV === "production",
-				sameSite: "lax",
-				path: "/",
-			});
-		}
 
 		return response;
 	}

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -10,6 +10,8 @@ import { verifyEmbedToken } from "@/lib/embed-token";
 import {
 	isPerVideoPasswordPayload,
 	MAX_PER_VIDEO_COOKIES,
+	PER_VIDEO_COOKIE_MAX_AGE_SECONDS,
+	PER_VIDEO_COOKIE_STALE_AFTER_SECONDS,
 	PER_VIDEO_PASSWORD_COOKIE_PREFIX,
 	perVideoPasswordCookieName,
 } from "@/lib/password-cookie-shared";
@@ -41,8 +43,6 @@ async function retiredPerVideoCookies(
 				cookie.name !== keepCookieName,
 		);
 
-	if (existing.length < MAX_PER_VIDEO_COOKIES) return [];
-
 	const dated = await Promise.all(
 		existing.map(async (cookie) => {
 			try {
@@ -55,10 +55,22 @@ async function retiredPerVideoCookies(
 		}),
 	);
 
-	return dated
-		.sort((a, b) => a.issuedAt - b.issuedAt)
-		.slice(0, existing.length - MAX_PER_VIDEO_COOKIES + 1)
-		.map((cookie) => cookie.name);
+	const nowSeconds = Math.floor(Date.now() / 1000);
+	const stale = dated.filter(
+		(cookie) =>
+			nowSeconds - cookie.issuedAt >= PER_VIDEO_COOKIE_STALE_AFTER_SECONDS,
+	);
+
+	const fresh = dated
+		.filter((cookie) => !stale.includes(cookie))
+		.sort((a, b) => a.issuedAt - b.issuedAt);
+
+	const overflow =
+		fresh.length >= MAX_PER_VIDEO_COOKIES
+			? fresh.slice(0, fresh.length - MAX_PER_VIDEO_COOKIES + 1)
+			: [];
+
+	return [...stale, ...overflow].map((cookie) => cookie.name);
 }
 
 function isFromAllowedEmbedOrigin(request: NextRequest): boolean {
@@ -179,7 +191,7 @@ export async function proxy(request: NextRequest) {
 				secure: process.env.NODE_ENV === "production",
 				sameSite: "lax",
 				path: "/",
-				maxAge: 3600,
+				maxAge: PER_VIDEO_COOKIE_MAX_AGE_SECONDS,
 			});
 		}
 

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -1,5 +1,5 @@
 import { db } from "@cap/database";
-import { encrypt } from "@cap/database/crypto";
+import { decrypt, encrypt } from "@cap/database/crypto";
 import { organizations, videos } from "@cap/database/schema";
 import { buildEnv, serverEnv } from "@cap/env";
 import type { Video } from "@cap/web-domain";
@@ -7,7 +7,12 @@ import { eq } from "drizzle-orm";
 import { notFound } from "next/navigation";
 import { type NextRequest, NextResponse, userAgent } from "next/server";
 import { verifyEmbedToken } from "@/lib/embed-token";
-import { perVideoPasswordCookieName } from "@/lib/password-cookie-shared";
+import {
+	isPerVideoPasswordPayload,
+	MAX_PER_VIDEO_COOKIES,
+	PER_VIDEO_PASSWORD_COOKIE_PREFIX,
+	perVideoPasswordCookieName,
+} from "@/lib/password-cookie-shared";
 
 const addHttps = (s?: string) => {
 	if (!s) return s;
@@ -23,6 +28,38 @@ const mainOrigins = [
 	addHttps(serverEnv().VERCEL_BRANCH_URL_HOST),
 	addHttps(serverEnv().VERCEL_PROJECT_PRODUCTION_URL_HOST),
 ].filter(Boolean) as string[];
+
+async function retiredPerVideoCookies(
+	request: NextRequest,
+	keepCookieName: string,
+): Promise<string[]> {
+	const existing = request.cookies
+		.getAll()
+		.filter(
+			(cookie) =>
+				cookie.name.startsWith(PER_VIDEO_PASSWORD_COOKIE_PREFIX) &&
+				cookie.name !== keepCookieName,
+		);
+
+	if (existing.length < MAX_PER_VIDEO_COOKIES) return [];
+
+	const dated = await Promise.all(
+		existing.map(async (cookie) => {
+			try {
+				const parsed: unknown = JSON.parse(await decrypt(cookie.value));
+				if (isPerVideoPasswordPayload(parsed)) {
+					return { name: cookie.name, issuedAt: parsed.t };
+				}
+			} catch {}
+			return { name: cookie.name, issuedAt: 0 };
+		}),
+	);
+
+	return dated
+		.sort((a, b) => a.issuedAt - b.issuedAt)
+		.slice(0, existing.length - MAX_PER_VIDEO_COOKIES + 1)
+		.map((cookie) => cookie.name);
+}
 
 function isFromAllowedEmbedOrigin(request: NextRequest): boolean {
 	const raw = serverEnv().ALLOWED_EMBED_ORIGINS;
@@ -101,7 +138,12 @@ export async function proxy(request: NextRequest) {
 						.from(videos)
 						.where(eq(videos.id, videoId as Video.VideoId));
 					if (video?.password) {
-						encryptedPassword = await encrypt(video.password);
+						encryptedPassword = await encrypt(
+							JSON.stringify({
+								h: video.password,
+								t: Math.floor(Date.now() / 1000),
+							}),
+						);
 					}
 				} catch (e) {
 					console.error("Embed password lookup failed:", e);
@@ -125,6 +167,13 @@ export async function proxy(request: NextRequest) {
 		response.headers.delete("X-Frame-Options");
 
 		if (encryptedPassword && passwordCookieName) {
+			for (const staleCookie of await retiredPerVideoCookies(
+				request,
+				passwordCookieName,
+			)) {
+				response.cookies.set(staleCookie, "", { path: "/", maxAge: 0 });
+			}
+
 			response.cookies.set(passwordCookieName, encryptedPassword, {
 				httpOnly: true,
 				secure: process.env.NODE_ENV === "production",

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -1,11 +1,13 @@
 import { db } from "@cap/database";
+import { encrypt } from "@cap/database/crypto";
 import { organizations, videos } from "@cap/database/schema";
 import { buildEnv, serverEnv } from "@cap/env";
 import type { Video } from "@cap/web-domain";
 import { eq } from "drizzle-orm";
 import { notFound } from "next/navigation";
 import { type NextRequest, NextResponse, userAgent } from "next/server";
-import { signEmbedToken, verifyEmbedToken } from "@/lib/embed-token";
+import { verifyEmbedToken } from "@/lib/embed-token";
+import { perVideoPasswordCookieName } from "@/lib/password-cookie-shared";
 
 const addHttps = (s?: string) => {
 	if (!s) return s;
@@ -73,45 +75,64 @@ export async function proxy(request: NextRequest) {
 	if (path.startsWith("/embed/")) {
 		const videoIdMatch = path.match(/^\/embed\/([^/]+)/);
 		const videoId = videoIdMatch?.[1];
-		let mintedTokenUrl: URL | null = null;
+		let encryptedPassword: string | null = null;
 
 		if (videoId) {
-			let hasValidToken = false;
+			let authenticated = false;
 
 			const token = url.searchParams.get("token");
 			if (token && token.length > 0 && token.length < 2048) {
 				try {
 					const result = await verifyEmbedToken(token, videoId);
-					hasValidToken = result.valid;
+					authenticated = result.valid;
 				} catch (e) {
 					console.error("Embed token verification failed:", e);
 				}
 			}
 
-			if (!hasValidToken && isFromAllowedEmbedOrigin(request)) {
+			if (!authenticated) {
+				authenticated = isFromAllowedEmbedOrigin(request);
+			}
+
+			if (authenticated) {
 				try {
 					const [video] = await db()
 						.select({ password: videos.password })
 						.from(videos)
 						.where(eq(videos.id, videoId as Video.VideoId));
-
 					if (video?.password) {
-						const mintedToken = await signEmbedToken(videoId, "24h");
-						mintedTokenUrl = new URL(url);
-						mintedTokenUrl.searchParams.set("token", mintedToken);
+						encryptedPassword = await encrypt(video.password);
 					}
 				} catch (e) {
-					console.error("Embed token minting failed:", e);
+					console.error("Embed password lookup failed:", e);
 				}
 			}
 		}
 
-		const response = mintedTokenUrl
-			? NextResponse.rewrite(mintedTokenUrl)
-			: NextResponse.next();
+		const passwordCookieName = videoId
+			? perVideoPasswordCookieName(videoId)
+			: null;
+
+		if (encryptedPassword && passwordCookieName) {
+			request.cookies.set(passwordCookieName, encryptedPassword);
+		}
+
+		const response = NextResponse.next({
+			request: { headers: request.headers },
+		});
 		response.headers.set("Access-Control-Allow-Origin", "*");
 		response.headers.set("Access-Control-Allow-Methods", "GET, OPTIONS");
 		response.headers.delete("X-Frame-Options");
+
+		if (encryptedPassword && passwordCookieName) {
+			response.cookies.set(passwordCookieName, encryptedPassword, {
+				httpOnly: true,
+				secure: process.env.NODE_ENV === "production",
+				sameSite: "lax",
+				path: "/",
+				maxAge: 3600,
+			});
+		}
 
 		return response;
 	}


### PR DESCRIPTION
## Symptom

Password-protected Cap videos embedded in an AFFiNE Edgeless board fail when two enter the viewport together — the first plays, the second shows *"Could not load a playable video source"*. Scrolling slowly so each loads alone always works.

## Cause

`proxy.ts` authorised trusted-origin embeds by writing the video's encrypted password hash into a **single shared `x-cap-password` cookie**. Two embeds loading concurrently both write it; the later `Set-Cookie` clobbers the earlier. The losing player's `/api/playlist` request then carries the *wrong video's* password and is refused.

Every observed detail follows from this: first works, second fails, sequential loading fine, only password-protected videos affected, reload changes which one loses.

Confirmed on production:

| Request | Result |
|---|---|
| password-protected video, cookieless `/api/playlist` | **403** |
| non-password video, 12 parallel cookieless probes | **12/12 → 206** |

## Why not just store an array

First attempt made the cookie hold an array, mirroring upstream's own `setVerifiedPasswordCookie` — whose comment says an array exists so "unlocking one resource never evicts another".

**That would not have fixed it.** Concurrent requests each read the same stale cookie before writing, so the last write still wins. Upstream's array is safe only because their unlocks are sequential and user-driven; embeds load in parallel. That approach was discarded.

## Fix

The proxy now mints a short-lived embed token and rewrites the request to carry it. The existing token path (issue #19) does the rest: the page authorises by token, `EmbedVideo` forwards it to every `/api/playlist` URL, and the playlist route verifies it.

No shared mutable state, so no race. It also works in the `credentialless` iframes AFFiNE uses, where cookies never arrive at all — something the cookie approach could never have handled.

## Not the cause

Earlier investigation pointed at Hetzner NBG1 capacity throttling. That is real and documented, but it is **not** this bug. No region move or CDN work is needed on this evidence.

## Verification

- `pnpm typecheck` — 0 errors
- Biome — clean
- `verify.sh` — all fork features present

## Testing

Open an Edgeless board with several password-protected embeds visible at once. They should all play. The `[playback-probe]` diagnostics already on staging will show whether any 403s remain.