### PR TITLE
Promote to production: embed concurrency fix + playback probe resilience

### DIFF
--- a/apps/web/__tests__/unit/password-cookie.test.ts
+++ b/apps/web/__tests__/unit/password-cookie.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const cookieStore = { entries: [] as { name: string; value: string }[] };
+
+vi.mock("server-only", () => ({}));
+vi.mock("next/headers", () => ({
+	cookies: async () => ({
+		getAll: () => cookieStore.entries,
+		get: (name: string) => cookieStore.entries.find((c) => c.name === name),
+		set: () => {},
+	}),
+}));
+vi.mock("@cap/database/crypto", () => ({
+	decrypt: async (value: string) => {
+		if (value.startsWith("bad")) throw new Error("cannot decrypt");
+		return value.replace(/^enc:/, "");
+	},
+	encrypt: async (value: string) => `enc:${value}`,
+}));
+
+import {
+	getVerifiedPasswordHashes,
+	perVideoPasswordCookieName,
+} from "@/lib/password-cookie";
+
+describe("perVideoPasswordCookieName", () => {
+	it("namespaces the cookie by video id", () => {
+		expect(perVideoPasswordCookieName("abc123")).toBe("x-cap-password-abc123");
+	});
+});
+
+describe("getVerifiedPasswordHashes", () => {
+	beforeEach(() => {
+		cookieStore.entries = [];
+	});
+
+	it("collects hashes from every per-video cookie", async () => {
+		cookieStore.entries = [
+			{ name: "x-cap-password-video1", value: "enc:hashOne" },
+			{ name: "x-cap-password-video2", value: "enc:hashTwo" },
+		];
+
+		await expect(getVerifiedPasswordHashes()).resolves.toEqual([
+			"hashOne",
+			"hashTwo",
+		]);
+	});
+
+	it("still reads the shared cookie alongside per-video cookies", async () => {
+		cookieStore.entries = [
+			{ name: "x-cap-password", value: 'enc:["sharedOne","sharedTwo"]' },
+			{ name: "x-cap-password-video1", value: "enc:hashOne" },
+		];
+
+		const hashes = await getVerifiedPasswordHashes();
+		expect(hashes).toContain("sharedOne");
+		expect(hashes).toContain("sharedTwo");
+		expect(hashes).toContain("hashOne");
+	});
+
+	it("ignores unrelated cookies", async () => {
+		cookieStore.entries = [
+			{ name: "next-auth.session-token", value: "enc:secret" },
+			{ name: "x-cap-password-video1", value: "enc:hashOne" },
+		];
+
+		await expect(getVerifiedPasswordHashes()).resolves.toEqual(["hashOne"]);
+	});
+
+	it("skips cookies that fail to decrypt without losing the others", async () => {
+		cookieStore.entries = [
+			{ name: "x-cap-password-video1", value: "badCookie" },
+			{ name: "x-cap-password-video2", value: "enc:hashTwo" },
+		];
+
+		await expect(getVerifiedPasswordHashes()).resolves.toEqual(["hashTwo"]);
+	});
+
+	it("deduplicates a hash present in several cookies", async () => {
+		cookieStore.entries = [
+			{ name: "x-cap-password-video1", value: "enc:sameHash" },
+			{ name: "x-cap-password-video2", value: "enc:sameHash" },
+		];
+
+		await expect(getVerifiedPasswordHashes()).resolves.toEqual(["sameHash"]);
+	});
+});

--- a/apps/web/__tests__/unit/password-cookie.test.ts
+++ b/apps/web/__tests__/unit/password-cookie.test.ts
@@ -85,3 +85,39 @@ describe("getVerifiedPasswordHashes", () => {
 		await expect(getVerifiedPasswordHashes()).resolves.toEqual(["sameHash"]);
 	});
 });
+
+describe("per-video cookie payloads", () => {
+	beforeEach(() => {
+		cookieStore.entries = [];
+	});
+
+	it("reads the timestamped payload format written by the proxy", async () => {
+		cookieStore.entries = [
+			{
+				name: "x-cap-password-video1",
+				value: 'enc:{"h":"hashOne","t":1700000000}',
+			},
+		];
+
+		await expect(getVerifiedPasswordHashes()).resolves.toEqual(["hashOne"]);
+	});
+
+	it("still reads bare-hash cookies written before the payload format", async () => {
+		cookieStore.entries = [
+			{ name: "x-cap-password-video1", value: "enc:legacyHash" },
+		];
+
+		await expect(getVerifiedPasswordHashes()).resolves.toEqual(["legacyHash"]);
+	});
+
+	it("mixes payload, legacy and shared-array cookies", async () => {
+		cookieStore.entries = [
+			{ name: "x-cap-password", value: 'enc:["sharedHash"]' },
+			{ name: "x-cap-password-video1", value: 'enc:{"h":"newHash","t":1}' },
+			{ name: "x-cap-password-video2", value: "enc:legacyHash" },
+		];
+
+		const hashes = await getVerifiedPasswordHashes();
+		expect(hashes.sort()).toEqual(["legacyHash", "newHash", "sharedHash"]);
+	});
+});

--- a/apps/web/__tests__/unit/playback-source.test.ts
+++ b/apps/web/__tests__/unit/playback-source.test.ts
@@ -399,3 +399,58 @@ describe("resolvePlaybackSource transient failures", () => {
 		expect(result).toBeNull();
 	});
 });
+
+describe("playback probe diagnostics", () => {
+	const noSleep = () => Promise.resolve();
+
+	it("logs the failing status and redacts the signed query string", async () => {
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const fetchImpl = vi
+			.fn<typeof fetch>()
+			.mockResolvedValue(
+				createResponse(
+					"https://storage.example/oa-cap/video.mp4?X-Amz-Signature=secret&_t=950",
+					{ status: 503 },
+				),
+			);
+
+		await resolvePlaybackSource({
+			videoSrc:
+				"https://storage.example/oa-cap/video.mp4?X-Amz-Signature=secret",
+			fetchImpl,
+			now: () => 950,
+			maxProbeAttempts: 2,
+			sleepImpl: noSleep,
+		});
+
+		const payloads = warn.mock.calls.map((call) => String(call[1]));
+		expect(payloads.length).toBe(2);
+		expect(payloads[0]).toContain('"status":503');
+		expect(payloads[0]).toContain('"willRetry":true');
+		expect(payloads[1]).toContain('"willRetry":false');
+		expect(payloads.join()).not.toContain("X-Amz-Signature");
+
+		warn.mockRestore();
+	});
+
+	it("records network errors with a null status", async () => {
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const fetchImpl = vi
+			.fn<typeof fetch>()
+			.mockRejectedValue(new TypeError("Failed to fetch"));
+
+		await resolvePlaybackSource({
+			videoSrc: "https://storage.example/video.mp4",
+			fetchImpl,
+			now: () => 960,
+			sleepImpl: noSleep,
+		});
+
+		expect(String(warn.mock.calls[0]?.[1])).toContain(
+			'"reason":"network-error"',
+		);
+		expect(String(warn.mock.calls[0]?.[1])).toContain('"status":null');
+
+		warn.mockRestore();
+	});
+});

--- a/apps/web/__tests__/unit/playback-source.test.ts
+++ b/apps/web/__tests__/unit/playback-source.test.ts
@@ -293,3 +293,109 @@ describe("shouldFallbackToRawPlaybackSource", () => {
 		);
 	});
 });
+
+describe("resolvePlaybackSource transient failures", () => {
+	const noSleep = () => Promise.resolve();
+
+	it("retries a transient 503 and uses the MP4 source once it recovers", async () => {
+		const fetchImpl = vi
+			.fn<typeof fetch>()
+			.mockResolvedValueOnce(
+				createResponse("/api/playlist?videoType=mp4&_t=500", { status: 503 }),
+			)
+			.mockResolvedValueOnce(
+				createResponse("/api/playlist?videoType=mp4&_t=500", { status: 206 }),
+			);
+
+		const result = await resolvePlaybackSource({
+			videoSrc: "/api/playlist?videoType=mp4",
+			rawFallbackSrc: "/api/playlist?videoType=raw-preview",
+			fetchImpl,
+			now: () => 500,
+			sleepImpl: noSleep,
+		});
+
+		expect(fetchImpl).toHaveBeenCalledTimes(2);
+		expect(result).toEqual({
+			url: "/api/playlist?videoType=mp4&_t=500",
+			type: "mp4",
+			supportsCrossOrigin: false,
+		});
+	});
+
+	it("retries 429 responses up to the attempt limit", async () => {
+		const fetchImpl = vi
+			.fn<typeof fetch>()
+			.mockResolvedValue(
+				createResponse("https://cdn.example/video.mp4?_t=600", { status: 429 }),
+			);
+
+		await resolvePlaybackSource({
+			videoSrc: "https://cdn.example/video.mp4",
+			fetchImpl,
+			now: () => 600,
+			maxProbeAttempts: 3,
+			sleepImpl: noSleep,
+		});
+
+		expect(fetchImpl).toHaveBeenCalledTimes(3);
+	});
+
+	it("does not retry deterministic 404 responses", async () => {
+		const fetchImpl = vi
+			.fn<typeof fetch>()
+			.mockResolvedValue(
+				createResponse("https://cdn.example/video.mp4?_t=700", { status: 404 }),
+			);
+
+		const result = await resolvePlaybackSource({
+			videoSrc: "https://cdn.example/video.mp4",
+			fetchImpl,
+			now: () => 700,
+			sleepImpl: noSleep,
+		});
+
+		expect(fetchImpl).toHaveBeenCalledTimes(1);
+		expect(result).toBeNull();
+	});
+
+	it("plays a same-origin MP4 optimistically when retries exhaust on a transient status", async () => {
+		const fetchImpl = vi
+			.fn<typeof fetch>()
+			.mockResolvedValue(
+				createResponse("/api/playlist?videoType=mp4&_t=800", { status: 503 }),
+			);
+
+		const result = await resolvePlaybackSource({
+			videoSrc: "/api/playlist?videoType=mp4",
+			fetchImpl,
+			now: () => 800,
+			maxProbeAttempts: 2,
+			sleepImpl: noSleep,
+		});
+
+		expect(fetchImpl).toHaveBeenCalledTimes(2);
+		expect(result).toEqual({
+			url: "/api/playlist?videoType=mp4&_t=800",
+			type: "mp4",
+			supportsCrossOrigin: false,
+		});
+	});
+
+	it("still returns null for same-origin sources that fail deterministically", async () => {
+		const fetchImpl = vi
+			.fn<typeof fetch>()
+			.mockResolvedValue(
+				createResponse("/api/playlist?videoType=mp4&_t=900", { status: 404 }),
+			);
+
+		const result = await resolvePlaybackSource({
+			videoSrc: "/api/playlist?videoType=mp4",
+			fetchImpl,
+			now: () => 900,
+			sleepImpl: noSleep,
+		});
+
+		expect(result).toBeNull();
+	});
+});

--- a/apps/web/app/s/[videoId]/_components/playback-source.ts
+++ b/apps/web/app/s/[videoId]/_components/playback-source.ts
@@ -38,6 +38,29 @@ const DEFAULT_PROBE_RETRY_DELAY_MS = 300;
 const defaultSleep = (ms: number) =>
 	new Promise<void>((resolve) => setTimeout(resolve, ms));
 
+function redactProbeUrl(url: string): string {
+	const [withoutQuery] = url.split("?");
+	return withoutQuery ?? url;
+}
+
+function reportProbeFailure(
+	failure: ProbeFailure,
+	attempt: number,
+	willRetry: boolean,
+) {
+	if (typeof console === "undefined") return;
+	console.warn(
+		"[playback-probe] source probe failed",
+		JSON.stringify({
+			url: redactProbeUrl(failure.url),
+			reason: failure.reason,
+			status: failure.status ?? null,
+			attempt,
+			willRetry,
+		}),
+	);
+}
+
 function isRetryableProbeStatus(status: number): boolean {
 	return status === 408 || status === 425 || status === 429 || status >= 500;
 }
@@ -85,8 +108,16 @@ async function probePlaybackSourceWithRetry(
 ): Promise<ProbeOutcome> {
 	let lastOutcome = await probePlaybackSource(url, fetchImpl, now);
 
-	for (let attempt = 1; attempt < maxAttempts; attempt++) {
-		if (isProbeResult(lastOutcome) || !isRetryableProbeFailure(lastOutcome)) {
+	for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+		if (isProbeResult(lastOutcome)) {
+			return lastOutcome;
+		}
+
+		const canRetry =
+			attempt < maxAttempts && isRetryableProbeFailure(lastOutcome);
+		reportProbeFailure(lastOutcome, attempt, canRetry);
+
+		if (!canRetry) {
 			return lastOutcome;
 		}
 

--- a/apps/web/app/s/[videoId]/_components/playback-source.ts
+++ b/apps/web/app/s/[videoId]/_components/playback-source.ts
@@ -14,6 +14,7 @@ type ProbeResult = {
 type ProbeFailure = {
 	url: string;
 	reason: "network-error" | "unavailable";
+	status?: number;
 };
 
 type ProbeOutcome = ProbeFailure | ProbeResult;
@@ -26,7 +27,28 @@ type ResolvePlaybackSourceInput = {
 	now?: () => number;
 	createVideoElement?: () => Pick<HTMLVideoElement, "canPlayType">;
 	preferredSource?: "mp4" | "raw";
+	maxProbeAttempts?: number;
+	probeRetryDelayMs?: number;
+	sleepImpl?: (ms: number) => Promise<void>;
 };
+
+const DEFAULT_MAX_PROBE_ATTEMPTS = 3;
+const DEFAULT_PROBE_RETRY_DELAY_MS = 300;
+
+const defaultSleep = (ms: number) =>
+	new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+function isRetryableProbeStatus(status: number): boolean {
+	return status === 408 || status === 425 || status === 429 || status >= 500;
+}
+
+function isRetryableProbeFailure(failure: ProbeFailure): boolean {
+	return (
+		failure.reason === "unavailable" &&
+		typeof failure.status === "number" &&
+		isRetryableProbeStatus(failure.status)
+	);
+}
 
 function appendCacheBust(url: string, timestamp: number): string {
 	return url.includes("?")
@@ -53,6 +75,28 @@ function isWebMContentType(contentType: string, url: string): boolean {
 	);
 }
 
+async function probePlaybackSourceWithRetry(
+	url: string,
+	fetchImpl: typeof fetch,
+	now: () => number,
+	maxAttempts: number,
+	retryDelayMs: number,
+	sleep: (ms: number) => Promise<void>,
+): Promise<ProbeOutcome> {
+	let lastOutcome = await probePlaybackSource(url, fetchImpl, now);
+
+	for (let attempt = 1; attempt < maxAttempts; attempt++) {
+		if (isProbeResult(lastOutcome) || !isRetryableProbeFailure(lastOutcome)) {
+			return lastOutcome;
+		}
+
+		await sleep(retryDelayMs * 2 ** (attempt - 1));
+		lastOutcome = await probePlaybackSource(url, fetchImpl, now);
+	}
+
+	return lastOutcome;
+}
+
 async function probePlaybackSource(
 	url: string,
 	fetchImpl: typeof fetch,
@@ -69,6 +113,7 @@ async function probePlaybackSource(
 			return {
 				url: requestUrl,
 				reason: "unavailable",
+				status: response.status,
 			};
 		}
 
@@ -136,13 +181,26 @@ export async function resolvePlaybackSource({
 	now = () => Date.now(),
 	createVideoElement,
 	preferredSource = "mp4",
+	maxProbeAttempts = DEFAULT_MAX_PROBE_ATTEMPTS,
+	probeRetryDelayMs = DEFAULT_PROBE_RETRY_DELAY_MS,
+	sleepImpl = defaultSleep,
 }: ResolvePlaybackSourceInput): Promise<ResolvedPlaybackSource | null> {
+	const probe = (url: string) =>
+		probePlaybackSourceWithRetry(
+			url,
+			fetchImpl,
+			now,
+			maxProbeAttempts,
+			probeRetryDelayMs,
+			sleepImpl,
+		);
+
 	const resolveRaw = async (): Promise<ResolvedPlaybackSource | null> => {
 		if (!rawFallbackSrc) {
 			return null;
 		}
 
-		const rawResult = await probePlaybackSource(rawFallbackSrc, fetchImpl, now);
+		const rawResult = await probe(rawFallbackSrc);
 
 		if (!isProbeResult(rawResult)) {
 			return null;
@@ -169,7 +227,7 @@ export async function resolvePlaybackSource({
 		return await resolveRaw();
 	}
 
-	const mp4Result = await probePlaybackSource(videoSrc, fetchImpl, now);
+	const mp4Result = await probe(videoSrc);
 
 	if (isProbeResult(mp4Result)) {
 		return {
@@ -181,7 +239,10 @@ export async function resolvePlaybackSource({
 		};
 	}
 
-	if (mp4Result.reason === "network-error" && canUseUnprobedSource(videoSrc)) {
+	const mp4FailureIsTransient =
+		mp4Result.reason === "network-error" || isRetryableProbeFailure(mp4Result);
+
+	if (mp4FailureIsTransient && canUseUnprobedSource(videoSrc)) {
 		return {
 			url: mp4Result.url,
 			type: "mp4",

--- a/apps/web/lib/password-cookie-shared.ts
+++ b/apps/web/lib/password-cookie-shared.ts
@@ -15,6 +15,12 @@ export function perVideoPasswordCookieName(videoId: string) {
 // the set is capped and the oldest entries are retired once it is reached.
 export const MAX_PER_VIDEO_COOKIES = 12;
 
+// Retirement is primarily age-based because that decision depends only on the
+// cookie being examined, so concurrent embeds reach the same answer instead of
+// racing over a shared view of the jar. The count cap is a backstop.
+export const PER_VIDEO_COOKIE_MAX_AGE_SECONDS = 3600;
+export const PER_VIDEO_COOKIE_STALE_AFTER_SECONDS = 1800;
+
 export type PerVideoPasswordPayload = {
 	h: string;
 	t: number;

--- a/apps/web/lib/password-cookie-shared.ts
+++ b/apps/web/lib/password-cookie-shared.ts
@@ -9,3 +9,24 @@ export const PER_VIDEO_PASSWORD_COOKIE_PREFIX = "x-cap-password-";
 export function perVideoPasswordCookieName(videoId: string) {
 	return `${PER_VIDEO_PASSWORD_COOKIE_PREFIX}${videoId}`;
 }
+
+// A viewer can open many distinct password-protected embeds inside the cookie
+// lifetime. Every per-video cookie is sent on every request to this origin, so
+// the set is capped and the oldest entries are retired once it is reached.
+export const MAX_PER_VIDEO_COOKIES = 12;
+
+export type PerVideoPasswordPayload = {
+	h: string;
+	t: number;
+};
+
+export function isPerVideoPasswordPayload(
+	value: unknown,
+): value is PerVideoPasswordPayload {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		typeof (value as PerVideoPasswordPayload).h === "string" &&
+		typeof (value as PerVideoPasswordPayload).t === "number"
+	);
+}

--- a/apps/web/lib/password-cookie-shared.ts
+++ b/apps/web/lib/password-cookie-shared.ts
@@ -1,0 +1,11 @@
+export const VERIFIED_PASSWORD_COOKIE = "x-cap-password";
+
+// Embeds authorise per video via `x-cap-password-<videoId>` cookies. Several
+// embeds can load in parallel, so they must not share one cookie: concurrent
+// requests each read the same stale value before writing, and the last
+// Set-Cookie would evict the others.
+export const PER_VIDEO_PASSWORD_COOKIE_PREFIX = "x-cap-password-";
+
+export function perVideoPasswordCookieName(videoId: string) {
+	return `${PER_VIDEO_PASSWORD_COOKIE_PREFIX}${videoId}`;
+}

--- a/apps/web/lib/password-cookie.ts
+++ b/apps/web/lib/password-cookie.ts
@@ -3,6 +3,7 @@ import "server-only";
 import { decrypt, encrypt } from "@cap/database/crypto";
 import { cookies } from "next/headers";
 import {
+	isPerVideoPasswordPayload,
 	PER_VIDEO_PASSWORD_COOKIE_PREFIX,
 	VERIFIED_PASSWORD_COOKIE,
 } from "./password-cookie-shared";
@@ -40,6 +41,9 @@ async function decodeHashes(cookieValue: string): Promise<string[]> {
 			parsed.every((hash) => typeof hash === "string")
 		) {
 			return parsed;
+		}
+		if (isPerVideoPasswordPayload(parsed)) {
+			return [parsed.h];
 		}
 	} catch {
 		// Legacy cookie: the decrypted value is the hash itself.

--- a/apps/web/lib/password-cookie.ts
+++ b/apps/web/lib/password-cookie.ts
@@ -2,8 +2,14 @@ import "server-only";
 
 import { decrypt, encrypt } from "@cap/database/crypto";
 import { cookies } from "next/headers";
+import {
+	PER_VIDEO_PASSWORD_COOKIE_PREFIX,
+	VERIFIED_PASSWORD_COOKIE,
+} from "./password-cookie-shared";
 
-const COOKIE_NAME = "x-cap-password";
+export { perVideoPasswordCookieName } from "./password-cookie-shared";
+
+const COOKIE_NAME = VERIFIED_PASSWORD_COOKIE;
 
 // A verified hash is ~64 base64 chars, so 10 entries encrypt to well under
 // the 4KB cookie limit while covering any realistic number of concurrently
@@ -16,10 +22,7 @@ const MAX_VERIFIED_HASHES = 10;
  * resource never evicts another; pre-array cookies that hold a single bare
  * hash are still accepted.
  */
-export async function getVerifiedPasswordHashes(): Promise<string[]> {
-	const cookieValue = (await cookies()).get(COOKIE_NAME)?.value;
-	if (!cookieValue) return [];
-
+async function decodeHashes(cookieValue: string): Promise<string[]> {
 	let decrypted: string;
 	try {
 		// decrypt is async — without the await its rejection (corrupt or stale
@@ -42,6 +45,23 @@ export async function getVerifiedPasswordHashes(): Promise<string[]> {
 		// Legacy cookie: the decrypted value is the hash itself.
 	}
 	return [decrypted];
+}
+
+export async function getVerifiedPasswordHashes(): Promise<string[]> {
+	const store = await cookies();
+	const relevant = store
+		.getAll()
+		.filter(
+			(cookie) =>
+				cookie.name === COOKIE_NAME ||
+				cookie.name.startsWith(PER_VIDEO_PASSWORD_COOKIE_PREFIX),
+		);
+
+	const decoded = await Promise.all(
+		relevant.map((cookie) => decodeHashes(cookie.value)),
+	);
+
+	return [...new Set(decoded.flat())];
 }
 
 /**

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -1,12 +1,11 @@
 import { db } from "@cap/database";
-import { encrypt } from "@cap/database/crypto";
 import { organizations, videos } from "@cap/database/schema";
 import { buildEnv, serverEnv } from "@cap/env";
 import type { Video } from "@cap/web-domain";
 import { eq } from "drizzle-orm";
 import { notFound } from "next/navigation";
 import { type NextRequest, NextResponse, userAgent } from "next/server";
-import { verifyEmbedToken } from "@/lib/embed-token";
+import { signEmbedToken, verifyEmbedToken } from "@/lib/embed-token";
 
 const addHttps = (s?: string) => {
 	if (!s) return s;
@@ -74,59 +73,45 @@ export async function proxy(request: NextRequest) {
 	if (path.startsWith("/embed/")) {
 		const videoIdMatch = path.match(/^\/embed\/([^/]+)/);
 		const videoId = videoIdMatch?.[1];
-		let encryptedPassword: string | null = null;
+		let mintedTokenUrl: URL | null = null;
 
 		if (videoId) {
-			let authenticated = false;
+			let hasValidToken = false;
 
 			const token = url.searchParams.get("token");
 			if (token && token.length > 0 && token.length < 2048) {
 				try {
 					const result = await verifyEmbedToken(token, videoId);
-					authenticated = result.valid;
+					hasValidToken = result.valid;
 				} catch (e) {
 					console.error("Embed token verification failed:", e);
 				}
 			}
 
-			if (!authenticated) {
-				authenticated = isFromAllowedEmbedOrigin(request);
-			}
-
-			if (authenticated) {
+			if (!hasValidToken && isFromAllowedEmbedOrigin(request)) {
 				try {
 					const [video] = await db()
 						.select({ password: videos.password })
 						.from(videos)
 						.where(eq(videos.id, videoId as Video.VideoId));
+
 					if (video?.password) {
-						encryptedPassword = await encrypt(video.password);
+						const mintedToken = await signEmbedToken(videoId, "24h");
+						mintedTokenUrl = new URL(url);
+						mintedTokenUrl.searchParams.set("token", mintedToken);
 					}
 				} catch (e) {
-					console.error("Embed password lookup failed:", e);
+					console.error("Embed token minting failed:", e);
 				}
 			}
 		}
 
-		if (encryptedPassword) {
-			request.cookies.set("x-cap-password", encryptedPassword);
-		}
-
-		const response = NextResponse.next({
-			request: { headers: request.headers },
-		});
+		const response = mintedTokenUrl
+			? NextResponse.rewrite(mintedTokenUrl)
+			: NextResponse.next();
 		response.headers.set("Access-Control-Allow-Origin", "*");
 		response.headers.set("Access-Control-Allow-Methods", "GET, OPTIONS");
 		response.headers.delete("X-Frame-Options");
-
-		if (encryptedPassword) {
-			response.cookies.set("x-cap-password", encryptedPassword, {
-				httpOnly: true,
-				secure: process.env.NODE_ENV === "production",
-				sameSite: "lax",
-				path: "/",
-			});
-		}
 
 		return response;
 	}

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -10,6 +10,8 @@ import { verifyEmbedToken } from "@/lib/embed-token";
 import {
 	isPerVideoPasswordPayload,
 	MAX_PER_VIDEO_COOKIES,
+	PER_VIDEO_COOKIE_MAX_AGE_SECONDS,
+	PER_VIDEO_COOKIE_STALE_AFTER_SECONDS,
 	PER_VIDEO_PASSWORD_COOKIE_PREFIX,
 	perVideoPasswordCookieName,
 } from "@/lib/password-cookie-shared";
@@ -41,8 +43,6 @@ async function retiredPerVideoCookies(
 				cookie.name !== keepCookieName,
 		);
 
-	if (existing.length < MAX_PER_VIDEO_COOKIES) return [];
-
 	const dated = await Promise.all(
 		existing.map(async (cookie) => {
 			try {
@@ -55,10 +55,22 @@ async function retiredPerVideoCookies(
 		}),
 	);
 
-	return dated
-		.sort((a, b) => a.issuedAt - b.issuedAt)
-		.slice(0, existing.length - MAX_PER_VIDEO_COOKIES + 1)
-		.map((cookie) => cookie.name);
+	const nowSeconds = Math.floor(Date.now() / 1000);
+	const stale = dated.filter(
+		(cookie) =>
+			nowSeconds - cookie.issuedAt >= PER_VIDEO_COOKIE_STALE_AFTER_SECONDS,
+	);
+
+	const fresh = dated
+		.filter((cookie) => !stale.includes(cookie))
+		.sort((a, b) => a.issuedAt - b.issuedAt);
+
+	const overflow =
+		fresh.length >= MAX_PER_VIDEO_COOKIES
+			? fresh.slice(0, fresh.length - MAX_PER_VIDEO_COOKIES + 1)
+			: [];
+
+	return [...stale, ...overflow].map((cookie) => cookie.name);
 }
 
 function isFromAllowedEmbedOrigin(request: NextRequest): boolean {
@@ -179,7 +191,7 @@ export async function proxy(request: NextRequest) {
 				secure: process.env.NODE_ENV === "production",
 				sameSite: "lax",
 				path: "/",
-				maxAge: 3600,
+				maxAge: PER_VIDEO_COOKIE_MAX_AGE_SECONDS,
 			});
 		}
 

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -1,5 +1,5 @@
 import { db } from "@cap/database";
-import { encrypt } from "@cap/database/crypto";
+import { decrypt, encrypt } from "@cap/database/crypto";
 import { organizations, videos } from "@cap/database/schema";
 import { buildEnv, serverEnv } from "@cap/env";
 import type { Video } from "@cap/web-domain";
@@ -7,7 +7,12 @@ import { eq } from "drizzle-orm";
 import { notFound } from "next/navigation";
 import { type NextRequest, NextResponse, userAgent } from "next/server";
 import { verifyEmbedToken } from "@/lib/embed-token";
-import { perVideoPasswordCookieName } from "@/lib/password-cookie-shared";
+import {
+	isPerVideoPasswordPayload,
+	MAX_PER_VIDEO_COOKIES,
+	PER_VIDEO_PASSWORD_COOKIE_PREFIX,
+	perVideoPasswordCookieName,
+} from "@/lib/password-cookie-shared";
 
 const addHttps = (s?: string) => {
 	if (!s) return s;
@@ -23,6 +28,38 @@ const mainOrigins = [
 	addHttps(serverEnv().VERCEL_BRANCH_URL_HOST),
 	addHttps(serverEnv().VERCEL_PROJECT_PRODUCTION_URL_HOST),
 ].filter(Boolean) as string[];
+
+async function retiredPerVideoCookies(
+	request: NextRequest,
+	keepCookieName: string,
+): Promise<string[]> {
+	const existing = request.cookies
+		.getAll()
+		.filter(
+			(cookie) =>
+				cookie.name.startsWith(PER_VIDEO_PASSWORD_COOKIE_PREFIX) &&
+				cookie.name !== keepCookieName,
+		);
+
+	if (existing.length < MAX_PER_VIDEO_COOKIES) return [];
+
+	const dated = await Promise.all(
+		existing.map(async (cookie) => {
+			try {
+				const parsed: unknown = JSON.parse(await decrypt(cookie.value));
+				if (isPerVideoPasswordPayload(parsed)) {
+					return { name: cookie.name, issuedAt: parsed.t };
+				}
+			} catch {}
+			return { name: cookie.name, issuedAt: 0 };
+		}),
+	);
+
+	return dated
+		.sort((a, b) => a.issuedAt - b.issuedAt)
+		.slice(0, existing.length - MAX_PER_VIDEO_COOKIES + 1)
+		.map((cookie) => cookie.name);
+}
 
 function isFromAllowedEmbedOrigin(request: NextRequest): boolean {
 	const raw = serverEnv().ALLOWED_EMBED_ORIGINS;
@@ -101,7 +138,12 @@ export async function proxy(request: NextRequest) {
 						.from(videos)
 						.where(eq(videos.id, videoId as Video.VideoId));
 					if (video?.password) {
-						encryptedPassword = await encrypt(video.password);
+						encryptedPassword = await encrypt(
+							JSON.stringify({
+								h: video.password,
+								t: Math.floor(Date.now() / 1000),
+							}),
+						);
 					}
 				} catch (e) {
 					console.error("Embed password lookup failed:", e);
@@ -125,6 +167,13 @@ export async function proxy(request: NextRequest) {
 		response.headers.delete("X-Frame-Options");
 
 		if (encryptedPassword && passwordCookieName) {
+			for (const staleCookie of await retiredPerVideoCookies(
+				request,
+				passwordCookieName,
+			)) {
+				response.cookies.set(staleCookie, "", { path: "/", maxAge: 0 });
+			}
+
 			response.cookies.set(passwordCookieName, encryptedPassword, {
 				httpOnly: true,
 				secure: process.env.NODE_ENV === "production",

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -1,11 +1,13 @@
 import { db } from "@cap/database";
+import { encrypt } from "@cap/database/crypto";
 import { organizations, videos } from "@cap/database/schema";
 import { buildEnv, serverEnv } from "@cap/env";
 import type { Video } from "@cap/web-domain";
 import { eq } from "drizzle-orm";
 import { notFound } from "next/navigation";
 import { type NextRequest, NextResponse, userAgent } from "next/server";
-import { signEmbedToken, verifyEmbedToken } from "@/lib/embed-token";
+import { verifyEmbedToken } from "@/lib/embed-token";
+import { perVideoPasswordCookieName } from "@/lib/password-cookie-shared";
 
 const addHttps = (s?: string) => {
 	if (!s) return s;
@@ -73,45 +75,64 @@ export async function proxy(request: NextRequest) {
 	if (path.startsWith("/embed/")) {
 		const videoIdMatch = path.match(/^\/embed\/([^/]+)/);
 		const videoId = videoIdMatch?.[1];
-		let mintedTokenUrl: URL | null = null;
+		let encryptedPassword: string | null = null;
 
 		if (videoId) {
-			let hasValidToken = false;
+			let authenticated = false;
 
 			const token = url.searchParams.get("token");
 			if (token && token.length > 0 && token.length < 2048) {
 				try {
 					const result = await verifyEmbedToken(token, videoId);
-					hasValidToken = result.valid;
+					authenticated = result.valid;
 				} catch (e) {
 					console.error("Embed token verification failed:", e);
 				}
 			}
 
-			if (!hasValidToken && isFromAllowedEmbedOrigin(request)) {
+			if (!authenticated) {
+				authenticated = isFromAllowedEmbedOrigin(request);
+			}
+
+			if (authenticated) {
 				try {
 					const [video] = await db()
 						.select({ password: videos.password })
 						.from(videos)
 						.where(eq(videos.id, videoId as Video.VideoId));
-
 					if (video?.password) {
-						const mintedToken = await signEmbedToken(videoId, "24h");
-						mintedTokenUrl = new URL(url);
-						mintedTokenUrl.searchParams.set("token", mintedToken);
+						encryptedPassword = await encrypt(video.password);
 					}
 				} catch (e) {
-					console.error("Embed token minting failed:", e);
+					console.error("Embed password lookup failed:", e);
 				}
 			}
 		}
 
-		const response = mintedTokenUrl
-			? NextResponse.rewrite(mintedTokenUrl)
-			: NextResponse.next();
+		const passwordCookieName = videoId
+			? perVideoPasswordCookieName(videoId)
+			: null;
+
+		if (encryptedPassword && passwordCookieName) {
+			request.cookies.set(passwordCookieName, encryptedPassword);
+		}
+
+		const response = NextResponse.next({
+			request: { headers: request.headers },
+		});
 		response.headers.set("Access-Control-Allow-Origin", "*");
 		response.headers.set("Access-Control-Allow-Methods", "GET, OPTIONS");
 		response.headers.delete("X-Frame-Options");
+
+		if (encryptedPassword && passwordCookieName) {
+			response.cookies.set(passwordCookieName, encryptedPassword, {
+				httpOnly: true,
+				secure: process.env.NODE_ENV === "production",
+				sameSite: "lax",
+				path: "/",
+				maxAge: 3600,
+			});
+		}
 
 		return response;
 	}


### PR DESCRIPTION
Promotes six commits from `oaris/staging`. Clean fast-forward.

## What ships

**1. Password-protected embeds failing when several load at once** (the user-visible bug)

The proxy authorised trusted-origin embeds by writing the video's password hash to a single shared `x-cap-password` cookie. Two embeds loading concurrently both wrote it and the later `Set-Cookie` evicted the earlier, so the losing player's `/api/playlist` carried the wrong video's password and was refused. Each video now gets `x-cap-password-<videoId>`; distinct names cannot clobber each other.

Cookies are bounded: retired by age after 30 minutes, with a count cap of 12 as a backstop. Age-based retirement depends only on the cookie being examined, so concurrent embeds reach the same answer instead of racing.

**2. Transient playback probe failures were terminal**

The source probe treated any non-2xx as fatal while a thrown fetch fell through and played anyway — backwards, since an HTTP error under load is more likely transient. Now retries 408/425/429/5xx with backoff, and same-origin sources play optimistically when retries exhaust. 404 still fails fast so genuinely missing videos keep falling back to the raw preview.

**3. Diagnostics**

Failed probes log reason, status and attempt, with signed query strings stripped. The failing requests go browser → object storage directly and never touch our logs, so this is the only way to see what a refused fetch returns.

## Review history

PR #26 went through four review rounds. Two approaches were built and discarded:

- Minting an embed token in the proxy — rejected because the token branch calls `fetchVideoByIdDirect` and bypasses `VideosPolicy`, which would have exposed metadata and comments for private and email-restricted videos.
- Count-based cookie eviction — rejected because it had the same read-modify-write race as the bug being fixed.

`apps/web/app/embed/[videoId]/page.tsx` is untouched in this diff, so no policy bypass ships.

## Open question

A final review comment argues cookies cannot reach a `credentialless` iframe at all and a token is required. Two observations contradict it: password embeds work today when loaded one at a time, and the race being fixed proves a shared cookie jar exists. Staging testing has not reproduced a failure. If a `403` appears in the `[playback-probe]` logs after this ships, the scoped-token design is the follow-up.

## Verification

- Full web unit suite — 1127 passed
- `pnpm typecheck` 0 errors, Biome clean, `verify.sh` all fork features present
- Staging image built and manually tested

## Note on process

Commits `601310c0a` and `b8768dd5e` went to staging without their own PRs. This PR is their first review surface.